### PR TITLE
Server preparations for beta test

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has guix; then
+    use guix -m requirements-dev.scm
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: watch-server dev-server
+
+watch-server:
+	watchexec -w server docker-compose restart server
+
+dev-server:
+	docker-compose up server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@ services:
       dockerfile: Dockerfile.dev
     environment:
       DIST_DIR: /opt/server/public
+      LUTRINE_DB: sqlite3:/var/data/lutrine-dice.db
     volumes:
       - ./server:/opt/server
+      - ./lutrine-dice.db:/var/data/lutrine-dice.db
       - ./client/dist:/opt/server/public
     working_dir: /opt/server
     command: crystal run src/main.cr -- --bind 0.0.0.0

--- a/requirements-dev.scm
+++ b/requirements-dev.scm
@@ -1,0 +1,7 @@
+(specifications->manifest
+ '(
+   "make"
+   "watchexec"
+   ;; crystal compiler (not in Guix yet)
+   ;; mint compiler (not in Guix yet)
+   ))

--- a/server/src/base58.cr
+++ b/server/src/base58.cr
@@ -1,9 +1,9 @@
 module Base58
   ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".chars
 
-  def self.random(n)
+  def self.random(n, generator = Random::Secure)
     String.build(n) do |result|
-      n.times { result << ALPHABET.sample(Random::Secure) }
+      n.times { result << ALPHABET.sample(generator) }
     end
   end
 end

--- a/server/src/flags.cr
+++ b/server/src/flags.cr
@@ -1,0 +1,11 @@
+module Lutrine::Flags
+
+  private def self.env?(*allowed : String)
+    allowed.includes? ENV.fetch("LUTRINE_ENV", "production")
+  end
+
+  def self.allow_cors?
+    env? "testing", "local"
+  end
+
+end

--- a/server/src/server.cr
+++ b/server/src/server.cr
@@ -1,6 +1,7 @@
 # TODO write documentation for `Server`
 
 require "./base58"
+require "./flags"
 require "./models/action"
 require "./models/room"
 require "./models/world"
@@ -11,6 +12,7 @@ include Lutrine
 WORLD = Server::World.load
 
 def add_cors_headers(env)
+  return unless Lutrine::Flags.allow_cors?
   env.response.headers.add("Access-Control-Allow-Origin", "*")
   env.response.headers.add("Access-Control-Allow-Headers", "*")
 end

--- a/server/src/server.cr
+++ b/server/src/server.cr
@@ -41,7 +41,7 @@ ws "/chat/:id" do |socket, ctx|
   WORLD.add_connection socket, room_id
 
   socket.on_message do |message|
-    p! message
+    Log.info { message }
     action = Server::Action.from_json message
     case action
     when Server::MessageAction

--- a/server/src/server.cr
+++ b/server/src/server.cr
@@ -1,6 +1,5 @@
 # TODO write documentation for `Server`
 
-require "./base58"
 require "./flags"
 require "./models/action"
 require "./models/room"


### PR DESCRIPTION
In this PR:
- Flags to allow or disallow CORS (will be disallowed on beta server, but are useful for local dev)
- Uses Log.info rather than `p!` macro to enable log levels
- Adds watchexec-based dev workflow with Makefile for easier local iteration