### PR TITLE
Room Invitations API

### DIFF
--- a/client/source/Api.mint
+++ b/client/source/Api.mint
@@ -32,4 +32,11 @@ store Api {
       |> Http.jsonBody(encode {name = Debug.log(name)})
       |> Http.send
   }
+
+  fun createInvite(roomId : String) {
+    "#{base}/api/room/#{roomId}/invite"
+      |> Http.post
+      |> Application.authRoom
+      |> Http.send
+  }
 }

--- a/client/source/Application.mint
+++ b/client/source/Application.mint
@@ -35,6 +35,15 @@ store Application {
     }
   }
 
+  fun authRoom(request : Http.Request) : Http.Request {
+    try {
+      case (view) {
+        View::Room(room) => Http.header("Authorization", "Bearer #{room.key}", request)
+        => request
+      }
+    }
+  }
+
   fun initialize {
     sequence {
       loadKeys()

--- a/client/source/Top.mint
+++ b/client/source/Top.mint
@@ -42,6 +42,23 @@ component Top {
     }
   }
 
+  fun handleInvite(event : Html.Event) {
+    sequence {
+      event |> Html.Event.preventDefault
+      response = case(view) {
+        View::Room(roomKey) => Api.createInvite(roomKey.room.id)
+          => `console.log('not in a room')` as Promise(Http.ErrorResponse, Http.Response)
+      }
+      Debug.log("got new key: #{response.body}")
+      Result::Ok(response.body)
+    } catch Http.ErrorResponse => error {
+      try {
+        Debug.log(error)
+        Result::Err(error)
+      }
+    }
+  }
+
   fun render {
     <section::top-navigation>
       <a::logo href="/">"Lutrine Dice"</a>
@@ -52,7 +69,7 @@ component Top {
           View::Room(place) => place.room.name
         }
       </span>
-      <span::invite><a href="#">"invite players"</a></span>
+      <span::invite><a href="#" onClick={handleInvite}>"invite players"</a></span>
     </section>
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       context: ./server
       dockerfile: Dockerfile.dev
     environment:
+      LUTRINE_ENV: local
       DIST_DIR: /opt/server/public
       LUTRINE_DB: sqlite3:/var/data/lutrine-dice.db
     volumes:


### PR DESCRIPTION
Currently the "invite players" UI is nonfunctional. This PR takes a big step in the direction of making it work by:
- adding a room invitation API to the backend
- creating an API client for it on the frontend
- hooking up the "invite players" link to invoke the API client

Next steps:
- format an invitation link from the data returned by the API
- show a modal popover with the invitation link
- copy the invitation link to the clipboard